### PR TITLE
go module を有効にする

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module github.com/devlights/try-golang
+
+go 1.12


### PR DESCRIPTION
# メモ

- GOPATHの中にいる状態で ```go mod``` すると以下のエラーが出る。

```sh
$ go mod init
go: modules disabled inside GOPATH/src by GO111MODULE=auto; see 'go help modules'
```

- GO111MODULEをonに設定して ```go mod```

```sh
$ export GO111MODULE=on
$ go mod init
go: creating new go.mod: module github.com/devlights/try-golang
```

GOPATH外の場合は、GO111MODULEを設定しなくても、普通に ```go mod``` できる

## 参照

[go1.11のmodulesの使い方について](https://qiita.com/yagi5/items/82989a5ecda70a614c27)
[Go 1.11 Modules](https://github.com/golang/go/wiki/Modules)