### PR TITLE
マッピングに絡む部分をリファクタリング

### DIFF
--- a/advanced/examples.go
+++ b/advanced/examples.go
@@ -21,7 +21,7 @@ func NewRegister() interfaces.Register {
 	return r
 }
 
-func (r *advancedExampleRegister) Regist(m interfaces.SampleMapping) {
+func (r *advancedExampleRegister) Regist(m interfaces.ExampleMapping) {
 	m["async01"] = async.Async01
 	m["async_producer_consumer"] = async.ProducerConsumer
 	m["closure01"] = closure.Closure01

--- a/advanced/examples.go
+++ b/advanced/examples.go
@@ -21,6 +21,7 @@ func NewRegister() interfaces.Register {
 	return r
 }
 
+// Regist は、advanced パッケージ配下に存在するサンプルを登録します.
 func (r *advancedExampleRegister) Regist(m interfaces.ExampleMapping) {
 	m["async01"] = async.Async01
 	m["async_producer_consumer"] = async.ProducerConsumer

--- a/advanced/examples.go
+++ b/advanced/examples.go
@@ -1,0 +1,40 @@
+package advanced
+
+import (
+	"github.com/devlights/try-golang/advanced/async"
+	"github.com/devlights/try-golang/advanced/closure"
+	"github.com/devlights/try-golang/advanced/crypto"
+	"github.com/devlights/try-golang/advanced/generate"
+	"github.com/devlights/try-golang/advanced/reflection"
+	"github.com/devlights/try-golang/advanced/sets"
+	"github.com/devlights/try-golang/advanced/xdgspec"
+	"github.com/devlights/try-golang/interfaces"
+)
+
+type (
+	advancedExampleRegister struct{}
+)
+
+// NewRegister は、advanced パッケージ用の lib.Register を返します.
+func NewRegister() interfaces.Register {
+	r := new(advancedExampleRegister)
+	return r
+}
+
+func (r *advancedExampleRegister) Regist(m interfaces.SampleMapping) {
+	m["async01"] = async.Async01
+	m["async_producer_consumer"] = async.ProducerConsumer
+	m["closure01"] = closure.Closure01
+	m["crypto_bcrypt_password_hash"] = crypto.BcryptPasswordHash
+	m["generate_generic_stack"] = generate.UseGenericStack
+	m["generate_generic_queue"] = generate.UseGenericQueue
+	m["reflection01"] = reflection.Reflection01
+	m["set01"] = sets.Set01
+	m["set02"] = sets.Set02
+	m["set03"] = sets.Set03
+	m["set04"] = sets.Set04
+	m["set05"] = sets.Set05
+	m["xdg_base_directory"] = xdgspec.XdgBaseDirectory
+	m["xdg_user_directory"] = xdgspec.XdgUserDirectory
+	m["xdg_file_operation"] = xdgspec.XdgFileOperation
+}

--- a/basic/examples.go
+++ b/basic/examples.go
@@ -45,7 +45,7 @@ func NewRegister() interfaces.Register {
 	return r
 }
 
-func (r *basicExampleRegister) Regist(m interfaces.SampleMapping) {
+func (r *basicExampleRegister) Regist(m interfaces.ExampleMapping) {
 	m["builtin_print"] = builtin_.PrintFunc
 	m["error_basic"] = error_.Basic
 	m["error_sentinel"] = error_.Sentinel

--- a/basic/examples.go
+++ b/basic/examples.go
@@ -1,0 +1,128 @@
+package basic
+
+import (
+	"github.com/devlights/try-golang/advanced/sets"
+	"github.com/devlights/try-golang/basic/array_"
+	"github.com/devlights/try-golang/basic/builtin_"
+	"github.com/devlights/try-golang/basic/comments"
+	"github.com/devlights/try-golang/basic/constants"
+	"github.com/devlights/try-golang/basic/defer_"
+	"github.com/devlights/try-golang/basic/error_"
+	"github.com/devlights/try-golang/basic/functions"
+	"github.com/devlights/try-golang/basic/helloworld"
+	"github.com/devlights/try-golang/basic/import_"
+	"github.com/devlights/try-golang/basic/interface_"
+	"github.com/devlights/try-golang/basic/io_"
+	"github.com/devlights/try-golang/basic/iota_"
+	"github.com/devlights/try-golang/basic/literals"
+	"github.com/devlights/try-golang/basic/log_"
+	"github.com/devlights/try-golang/basic/map_"
+	"github.com/devlights/try-golang/basic/math_"
+	"github.com/devlights/try-golang/basic/os_"
+	"github.com/devlights/try-golang/basic/runtime_"
+	"github.com/devlights/try-golang/basic/scope"
+	"github.com/devlights/try-golang/basic/slice_"
+	"github.com/devlights/try-golang/basic/sort_"
+	"github.com/devlights/try-golang/basic/stdin"
+	"github.com/devlights/try-golang/basic/stdout"
+	"github.com/devlights/try-golang/basic/strconv_"
+	"github.com/devlights/try-golang/basic/string_"
+	"github.com/devlights/try-golang/basic/struct_"
+	"github.com/devlights/try-golang/basic/time_"
+	"github.com/devlights/try-golang/basic/type_"
+	"github.com/devlights/try-golang/basic/unsafe_"
+	"github.com/devlights/try-golang/basic/variables"
+	"github.com/devlights/try-golang/interfaces"
+)
+
+type (
+	basicExampleRegister struct{}
+)
+
+// NewRegister は、basic パッケージ用の lib.Register を返します.
+func NewRegister() interfaces.Register {
+	r := new(basicExampleRegister)
+	return r
+}
+
+func (r *basicExampleRegister) Regist(m interfaces.SampleMapping) {
+	m["builtin_print"] = builtin_.PrintFunc
+	m["error_basic"] = error_.Basic
+	m["error_sentinel"] = error_.Sentinel
+	m["error_typeassertion"] = error_.TypeAssertion
+	m["error_wrap_unwrap"] = error_.WrapAndUnwrap
+	m["helloworld"] = helloworld.HelloWorld
+	m["printf01"] = stdout.Printf01
+	m["printf02"] = stdout.Printf02
+	m["printf03"] = stdout.Printf03
+	m["println01"] = stdout.Println01
+	m["scanner01"] = stdin.Scanner01
+	m["map_basic"] = map_.MapBasic
+	m["map_for"] = map_.MapFor
+	m["map_initialize"] = map_.MapInitialize
+	m["map_delete"] = map_.MapDelete
+	m["map_access"] = map_.MapAccess
+	m["scope01"] = scope.Scope01
+	m["import01"] = import_.Import01
+	m["iota01"] = iota_.Iota01
+	m["fileio01"] = io_.FileIo01
+	m["fileio02"] = io_.FileIo02
+	m["fileio03"] = io_.FileIo03
+	m["fileio04"] = io_.FileIo04
+	m["interface_basic"] = interface_.Basic
+	m["interface_composition"] = interface_.Composition
+	m["interface_ducktyping"] = interface_.DuckTyping
+	m["os01"] = os_.Os01
+	m["runtime01"] = runtime_.Runtime01
+	m["struct01"] = struct_.Struct01
+	m["struct02"] = struct_.Struct02
+	m["struct03"] = struct_.Struct03
+	m["struct04"] = struct_.Struct04
+	m["struct_anonymous_struct"] = struct_.StructAnonymousStruct
+	m["struct_empty_struct"] = struct_.EmptyStruct
+	m["array01"] = array_.Array01
+	m["slice01"] = slice_.Slice01
+	m["slice02"] = slice_.Slice02
+	m["slice03"] = slice_.Slice03
+	m["slice04"] = slice_.Slice04
+	m["slice05"] = slice_.Slice05
+	m["slice_reverse"] = slice_.SliceReverse
+	m["slice_append"] = slice_.SliceAppend
+	m["slice_pointer"] = slice_.SlicePointer
+	m["slice_copy"] = slice_.SliceCopy
+	m["slice_clear"] = slice_.SliceClear
+	m["comment01"] = comments.Comment01
+	m["string_rune_rawstring"] = string_.StringRuneRawString
+	m["string_to_runeslice"] = string_.StringToRuneSlice
+	m["string_rune_byte_convert"] = string_.StringRuneByteConvert
+	m["mapset01"] = sets.MapSet01
+	m["defer01"] = defer_.Defer01
+	m["var_statement_declare"] = variables.VarStatementDeclares
+	m["package_scope_variable"] = variables.PackageScopeVariable
+	m["short_assignment_statement"] = variables.ShortAssignmentStatement
+	m["const_statement_declare"] = constants.ConstStatementDeclares
+	m["function_one_return_value"] = functions.FunctionOneReturnValue
+	m["function_multi_return_value"] = functions.FunctionMultiReturnValue
+	m["function_named_return_value"] = functions.FunctionNamedReturnValue
+	m["type01"] = type_.Type01
+	m["minmax"] = math_.MinMax
+	m["binary_int_literals"] = literals.BinaryIntLiterals
+	m["octal_int_literals"] = literals.OctalIntLiterals
+	m["hex_int_literals"] = literals.HexIntLiterals
+	m["digit_separator"] = literals.DigitSeparators
+	m["time_since"] = time_.TimeSince
+	m["time_after"] = time_.TimeAfter
+	m["time_unix_to_time"] = time_.TimeUnixToTime
+	m["time_now"] = time_.TimeNow
+	m["time_parse"] = time_.TimeParse
+	m["hex_to_decimal_convert"] = strconv_.HexToDecimalConvert
+	m["unsafe_sizeof"] = unsafe_.Sizeof
+	m["log_flags"] = log_.Flags
+	m["log_prefix"] = log_.Prefix
+	m["log_sentry_basic"] = log_.SentryBasic
+	m["log_sentry_goroutine_bad"] = log_.SentryGoroutineBad
+	m["log_sentry_goroutine_good"] = log_.SentryGoroutineGood
+	m["log_output"] = log_.Output
+	m["log_new"] = log_.NewLogger
+	m["sort_interface"] = sort_.SortInterface
+}

--- a/basic/examples.go
+++ b/basic/examples.go
@@ -45,6 +45,7 @@ func NewRegister() interfaces.Register {
 	return r
 }
 
+// Regist は、basic パッケージ配下に存在するサンプルを登録します.
 func (r *basicExampleRegister) Regist(m interfaces.ExampleMapping) {
 	m["builtin_print"] = builtin_.PrintFunc
 	m["error_basic"] = error_.Basic

--- a/books/examples.go
+++ b/books/examples.go
@@ -15,5 +15,5 @@ func NewRegister() interfaces.Register {
 }
 
 //noinspection GoUnusedParameter
-func (r *booksExampleRegister) Regist(m interfaces.SampleMapping) {
+func (r *booksExampleRegister) Regist(m interfaces.ExampleMapping) {
 }

--- a/books/examples.go
+++ b/books/examples.go
@@ -14,6 +14,7 @@ func NewRegister() interfaces.Register {
 	return r
 }
 
+// Regist は、books パッケージ配下に存在するサンプルを登録します.
 //noinspection GoUnusedParameter
 func (r *booksExampleRegister) Regist(m interfaces.ExampleMapping) {
 }

--- a/books/examples.go
+++ b/books/examples.go
@@ -1,0 +1,19 @@
+package books
+
+import (
+	"github.com/devlights/try-golang/interfaces"
+)
+
+type (
+	booksExampleRegister struct{}
+)
+
+// NewRegister は、books パッケージ用の lib.Register を返します.
+func NewRegister() interfaces.Register {
+	r := new(booksExampleRegister)
+	return r
+}
+
+//noinspection GoUnusedParameter
+func (r *booksExampleRegister) Regist(m interfaces.SampleMapping) {
+}

--- a/cmd/trygolang/errs.go
+++ b/cmd/trygolang/errs.go
@@ -7,7 +7,7 @@ import (
 
 type (
 	ExecError struct {
-		Name interfaces.SampleKey
+		Name interfaces.ExampleKey
 		Err  error
 	}
 )

--- a/cmd/trygolang/errs.go
+++ b/cmd/trygolang/errs.go
@@ -2,12 +2,12 @@ package main
 
 import (
 	"fmt"
-	"github.com/devlights/try-golang/lib"
+	"github.com/devlights/try-golang/interfaces"
 )
 
 type (
 	ExecError struct {
-		Name lib.SampleKey
+		Name interfaces.SampleKey
 		Err  error
 	}
 )

--- a/cmd/trygolang/exec.go
+++ b/cmd/trygolang/exec.go
@@ -12,11 +12,11 @@ type (
 
 	ExecArgs struct {
 		Target  string
-		Mapping interfaces.SampleMapping
+		Mapping interfaces.ExampleMapping
 	}
 )
 
-func NewExecArgs(target string, mapping interfaces.SampleMapping) *ExecArgs {
+func NewExecArgs(target string, mapping interfaces.ExampleMapping) *ExecArgs {
 	a := new(ExecArgs)
 	a.Target = target
 	a.Mapping = mapping
@@ -31,7 +31,7 @@ func NewExecCommand(args *ExecArgs) *ExecCommand {
 
 func (c *ExecCommand) Run() error {
 	var (
-		target  = interfaces.SampleKey(c.Args.Target)
+		target  = interfaces.ExampleKey(c.Args.Target)
 		mapping = c.Args.Mapping
 	)
 

--- a/cmd/trygolang/exec.go
+++ b/cmd/trygolang/exec.go
@@ -2,7 +2,7 @@ package main
 
 import (
 	"fmt"
-	"github.com/devlights/try-golang/lib"
+	"github.com/devlights/try-golang/interfaces"
 )
 
 type (
@@ -12,11 +12,11 @@ type (
 
 	ExecArgs struct {
 		Target  string
-		Mapping lib.SampleMapping
+		Mapping interfaces.SampleMapping
 	}
 )
 
-func NewExecArgs(target string, mapping lib.SampleMapping) *ExecArgs {
+func NewExecArgs(target string, mapping interfaces.SampleMapping) *ExecArgs {
 	a := new(ExecArgs)
 	a.Target = target
 	a.Mapping = mapping
@@ -31,7 +31,7 @@ func NewExecCommand(args *ExecArgs) *ExecCommand {
 
 func (c *ExecCommand) Run() error {
 	var (
-		target  = lib.SampleKey(c.Args.Target)
+		target  = interfaces.SampleKey(c.Args.Target)
 		mapping = c.Args.Mapping
 	)
 

--- a/cmd/trygolang/main.go
+++ b/cmd/trygolang/main.go
@@ -11,7 +11,7 @@ import (
 func main() {
 	var (
 		args    *Args
-		mapping interfaces.SampleMapping
+		mapping interfaces.ExampleMapping
 	)
 
 	args = NewArgs()

--- a/cmd/trygolang/main.go
+++ b/cmd/trygolang/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"fmt"
+	"github.com/devlights/try-golang/interfaces"
 	"github.com/devlights/try-golang/lib"
 	"log"
 	"os"
@@ -10,14 +11,13 @@ import (
 func main() {
 	var (
 		args    *Args
-		mapping lib.SampleMapping
+		mapping interfaces.SampleMapping
 	)
 
 	args = NewArgs()
 	args.Parse()
 
-	mapping = lib.NewSampleMapping()
-	mapping.MakeMapping()
+	mapping = lib.MakeMapping()
 
 	if args.ShowNames {
 		printAllExampleNames(mapping)

--- a/cmd/trygolang/runloop.go
+++ b/cmd/trygolang/runloop.go
@@ -3,7 +3,7 @@ package main
 import (
 	"bufio"
 	"fmt"
-	"github.com/devlights/try-golang/lib"
+	"github.com/devlights/try-golang/interfaces"
 	"os"
 	"sort"
 	"strings"
@@ -16,11 +16,11 @@ type (
 
 	RunLoopArgs struct {
 		MainArgs *Args
-		Mapping  lib.SampleMapping
+		Mapping  interfaces.SampleMapping
 	}
 )
 
-func NewRunLoopArgs(mainArgs *Args, mapping lib.SampleMapping) *RunLoopArgs {
+func NewRunLoopArgs(mainArgs *Args, mapping interfaces.SampleMapping) *RunLoopArgs {
 	a := new(RunLoopArgs)
 	a.MainArgs = mainArgs
 	a.Mapping = mapping
@@ -110,7 +110,7 @@ func (c *RunLoopCommand) Run() error {
 	return nil
 }
 
-func (c *RunLoopCommand) exec(target string, mapping lib.SampleMapping) error {
+func (c *RunLoopCommand) exec(target string, mapping interfaces.SampleMapping) error {
 	execArgs := NewExecArgs(target, mapping)
 	execCmd := NewExecCommand(execArgs)
 
@@ -121,7 +121,7 @@ func (c *RunLoopCommand) exec(target string, mapping lib.SampleMapping) error {
 	return nil
 }
 
-func (c *RunLoopCommand) makeCandidates(userInput string, mapping lib.SampleMapping) []string {
+func (c *RunLoopCommand) makeCandidates(userInput string, mapping interfaces.SampleMapping) []string {
 	candidates := make([]string, 0, len(mapping))
 	for k := range mapping {
 		key := string(k)

--- a/cmd/trygolang/runloop.go
+++ b/cmd/trygolang/runloop.go
@@ -16,11 +16,11 @@ type (
 
 	RunLoopArgs struct {
 		MainArgs *Args
-		Mapping  interfaces.SampleMapping
+		Mapping  interfaces.ExampleMapping
 	}
 )
 
-func NewRunLoopArgs(mainArgs *Args, mapping interfaces.SampleMapping) *RunLoopArgs {
+func NewRunLoopArgs(mainArgs *Args, mapping interfaces.ExampleMapping) *RunLoopArgs {
 	a := new(RunLoopArgs)
 	a.MainArgs = mainArgs
 	a.Mapping = mapping
@@ -110,7 +110,7 @@ func (c *RunLoopCommand) Run() error {
 	return nil
 }
 
-func (c *RunLoopCommand) exec(target string, mapping interfaces.SampleMapping) error {
+func (c *RunLoopCommand) exec(target string, mapping interfaces.ExampleMapping) error {
 	execArgs := NewExecArgs(target, mapping)
 	execCmd := NewExecCommand(execArgs)
 
@@ -121,7 +121,7 @@ func (c *RunLoopCommand) exec(target string, mapping interfaces.SampleMapping) e
 	return nil
 }
 
-func (c *RunLoopCommand) makeCandidates(userInput string, mapping interfaces.SampleMapping) []string {
+func (c *RunLoopCommand) makeCandidates(userInput string, mapping interfaces.ExampleMapping) []string {
 	candidates := make([]string, 0, len(mapping))
 	for k := range mapping {
 		key := string(k)

--- a/cmd/trygolang/runonce.go
+++ b/cmd/trygolang/runonce.go
@@ -14,7 +14,7 @@ type (
 	}
 )
 
-func NewRunOnceArgs(target string, mapping interfaces.SampleMapping) *RunOnceArgs {
+func NewRunOnceArgs(target string, mapping interfaces.ExampleMapping) *RunOnceArgs {
 	a := new(RunOnceArgs)
 	a.Target = target
 	a.Mapping = mapping

--- a/cmd/trygolang/runonce.go
+++ b/cmd/trygolang/runonce.go
@@ -1,6 +1,8 @@
 package main
 
-import "github.com/devlights/try-golang/lib"
+import (
+	"github.com/devlights/try-golang/interfaces"
+)
 
 type (
 	RunOnceCommand struct {
@@ -12,7 +14,7 @@ type (
 	}
 )
 
-func NewRunOnceArgs(target string, mapping lib.SampleMapping) *RunOnceArgs {
+func NewRunOnceArgs(target string, mapping interfaces.SampleMapping) *RunOnceArgs {
 	a := new(RunOnceArgs)
 	a.Target = target
 	a.Mapping = mapping

--- a/cmd/trygolang/utils.go
+++ b/cmd/trygolang/utils.go
@@ -6,7 +6,7 @@ import (
 	"sort"
 )
 
-func printAllExampleNames(mapping interfaces.SampleMapping) {
+func printAllExampleNames(mapping interfaces.ExampleMapping) {
 	names := make([]string, 0, len(mapping))
 
 	for k := range mapping {

--- a/cmd/trygolang/utils.go
+++ b/cmd/trygolang/utils.go
@@ -2,11 +2,11 @@ package main
 
 import (
 	"fmt"
-	"github.com/devlights/try-golang/lib"
+	"github.com/devlights/try-golang/interfaces"
 	"sort"
 )
 
-func printAllExampleNames(mapping lib.SampleMapping) {
+func printAllExampleNames(mapping interfaces.SampleMapping) {
 	names := make([]string, 0, len(mapping))
 
 	for k := range mapping {

--- a/effectivego/examples.go
+++ b/effectivego/examples.go
@@ -1,0 +1,37 @@
+package effectivego
+
+import (
+	"github.com/devlights/try-golang/interfaces"
+)
+
+type (
+	effectivegoExampleRegister struct{}
+)
+
+// NewRegister は、effectivego パッケージ用の lib.Register を返します.
+func NewRegister() interfaces.Register {
+	r := new(effectivegoExampleRegister)
+	return r
+}
+
+func (r *effectivegoExampleRegister) Regist(m interfaces.SampleMapping) {
+	m["effective_go_intro"] = Introduction
+	m["effective_go_formatting"] = Formatting
+	m["effective_go_comment"] = Commentary
+	m["effective_go_names"] = Names
+	m["effective_go_semicolon"] = Semicolons
+	m["effective_go_control"] = ControlStructure
+	m["effective_go_functions"] = Functions
+	m["effective_go_defer"] = Defer
+	m["effective_go_allocation_with_new"] = AllocationWithNew
+	m["effective_go_constructors"] = Constructors
+	m["effective_go_allocation_with_make"] = AllocationWithMake
+	m["effective_go_arrays"] = Arrays
+	m["effective_go_slices"] = Slices
+	m["effective_go_two_dimentional_slices"] = TwoDimentionalSlices
+	m["effective_go_maps"] = Maps
+	m["effective_go_printing"] = Printing
+	m["effective_go_append"] = Append
+	m["effective_go_constants"] = Constants
+	m["effective_go_methods"] = Methods
+}

--- a/effectivego/examples.go
+++ b/effectivego/examples.go
@@ -14,6 +14,7 @@ func NewRegister() interfaces.Register {
 	return r
 }
 
+// Regist は、effectivego パッケージ配下に存在するサンプルを登録します.
 func (r *effectivegoExampleRegister) Regist(m interfaces.ExampleMapping) {
 	m["effective_go_intro"] = Introduction
 	m["effective_go_formatting"] = Formatting

--- a/effectivego/examples.go
+++ b/effectivego/examples.go
@@ -14,7 +14,7 @@ func NewRegister() interfaces.Register {
 	return r
 }
 
-func (r *effectivegoExampleRegister) Regist(m interfaces.SampleMapping) {
+func (r *effectivegoExampleRegister) Regist(m interfaces.ExampleMapping) {
 	m["effective_go_intro"] = Introduction
 	m["effective_go_formatting"] = Formatting
 	m["effective_go_comment"] = Commentary

--- a/interfaces/register.go
+++ b/interfaces/register.go
@@ -1,0 +1,9 @@
+package interfaces
+
+type (
+	// Register は、各パッケージ毎のサンプルを登録するためのインターフェースです.
+	Register interface {
+		// 指定されたマッピングに自身のサンプル情報を登録します.
+		Regist(m SampleMapping)
+	}
+)

--- a/interfaces/register.go
+++ b/interfaces/register.go
@@ -4,6 +4,6 @@ type (
 	// Register は、各パッケージ毎のサンプルを登録するためのインターフェースです.
 	Register interface {
 		// 指定されたマッピングに自身のサンプル情報を登録します.
-		Regist(m SampleMapping)
+		Regist(m ExampleMapping)
 	}
 )

--- a/interfaces/types.go
+++ b/interfaces/types.go
@@ -1,0 +1,24 @@
+package interfaces
+
+type (
+	// SampleKeyは、サンプル名を表すキーを表します
+	SampleKey string
+
+	// SampleFuncは、実行するサンプル処理を表します
+	SampleFunc func() error
+
+	// SampleMappingは、サンプルのマッピング定義を表します
+	SampleMapping map[SampleKey]SampleFunc
+)
+
+// NewSampleMapping は、SampleMappingのコンストラクタ関数です
+func NewSampleMapping() SampleMapping {
+	return make(SampleMapping)
+}
+
+// MakeMapping は、マッピングを生成します
+func (m SampleMapping) MakeMapping(registers ...Register) {
+	for _, register := range registers {
+		register.Regist(m)
+	}
+}

--- a/interfaces/types.go
+++ b/interfaces/types.go
@@ -2,22 +2,22 @@ package interfaces
 
 type (
 	// SampleKeyは、サンプル名を表すキーを表します
-	SampleKey string
+	ExampleKey string
 
 	// SampleFuncは、実行するサンプル処理を表します
-	SampleFunc func() error
+	ExampleFunc func() error
 
 	// SampleMappingは、サンプルのマッピング定義を表します
-	SampleMapping map[SampleKey]SampleFunc
+	ExampleMapping map[ExampleKey]ExampleFunc
 )
 
 // NewSampleMapping は、SampleMappingのコンストラクタ関数です
-func NewSampleMapping() SampleMapping {
-	return make(SampleMapping)
+func NewSampleMapping() ExampleMapping {
+	return make(ExampleMapping)
 }
 
 // MakeMapping は、マッピングを生成します
-func (m SampleMapping) MakeMapping(registers ...Register) {
+func (m ExampleMapping) MakeMapping(registers ...Register) {
 	for _, register := range registers {
 		register.Regist(m)
 	}

--- a/lib/mapping.go
+++ b/lib/mapping.go
@@ -10,7 +10,7 @@ import (
 )
 
 // MakeMapping は、サンプル実行のためのマッピング情報を生成します.
-func MakeMapping() interfaces.SampleMapping {
+func MakeMapping() interfaces.ExampleMapping {
 	mapping := interfaces.NewSampleMapping()
 
 	mapping.MakeMapping(

--- a/lib/mapping.go
+++ b/lib/mapping.go
@@ -1,202 +1,25 @@
 package lib
 
 import (
-	"github.com/devlights/try-golang/advanced/async"
-	"github.com/devlights/try-golang/advanced/closure"
-	"github.com/devlights/try-golang/advanced/crypto"
-	"github.com/devlights/try-golang/advanced/generate"
-	"github.com/devlights/try-golang/advanced/reflection"
-	"github.com/devlights/try-golang/advanced/sets"
-	"github.com/devlights/try-golang/advanced/xdgspec"
-	"github.com/devlights/try-golang/basic/array_"
-	"github.com/devlights/try-golang/basic/builtin_"
-	"github.com/devlights/try-golang/basic/comments"
-	"github.com/devlights/try-golang/basic/constants"
-	"github.com/devlights/try-golang/basic/defer_"
-	"github.com/devlights/try-golang/basic/error_"
-	"github.com/devlights/try-golang/basic/functions"
-	"github.com/devlights/try-golang/basic/helloworld"
-	"github.com/devlights/try-golang/basic/import_"
-	"github.com/devlights/try-golang/basic/interface_"
-	"github.com/devlights/try-golang/basic/io_"
-	"github.com/devlights/try-golang/basic/iota_"
-	"github.com/devlights/try-golang/basic/literals"
-	"github.com/devlights/try-golang/basic/log_"
-	"github.com/devlights/try-golang/basic/map_"
-	"github.com/devlights/try-golang/basic/math_"
-	"github.com/devlights/try-golang/basic/os_"
-	"github.com/devlights/try-golang/basic/runtime_"
-	"github.com/devlights/try-golang/basic/scope"
-	"github.com/devlights/try-golang/basic/slice_"
-	"github.com/devlights/try-golang/basic/sort_"
-	"github.com/devlights/try-golang/basic/stdin"
-	"github.com/devlights/try-golang/basic/stdout"
-	"github.com/devlights/try-golang/basic/strconv_"
-	"github.com/devlights/try-golang/basic/string_"
-	"github.com/devlights/try-golang/basic/struct_"
-	"github.com/devlights/try-golang/basic/time_"
-	"github.com/devlights/try-golang/basic/type_"
-	"github.com/devlights/try-golang/basic/unsafe_"
-	"github.com/devlights/try-golang/basic/variables"
+	"github.com/devlights/try-golang/advanced"
+	"github.com/devlights/try-golang/basic"
+	"github.com/devlights/try-golang/books"
 	"github.com/devlights/try-golang/effectivego"
+	"github.com/devlights/try-golang/interfaces"
 	"github.com/devlights/try-golang/tutorial"
 )
 
-type (
-	SampleKey     string                   // SampleKeyは、サンプル名を表すキーを表します
-	SampleFunc    func() error             // SampleFuncは、実行するサンプル処理を表します
-	SampleMapping map[SampleKey]SampleFunc // SampleMappingは、サンプルのマッピング定義を表します
-)
+// MakeMapping は、サンプル実行のためのマッピング情報を生成します.
+func MakeMapping() interfaces.SampleMapping {
+	mapping := interfaces.NewSampleMapping()
 
-// NewSampleMapping は、SampleMappingのコンストラクタ関数です
-func NewSampleMapping() SampleMapping {
-	return make(SampleMapping)
-}
+	mapping.MakeMapping(
+		advanced.NewRegister(),
+		basic.NewRegister(),
+		books.NewRegister(),
+		effectivego.NewRegister(),
+		tutorial.NewRegister(),
+	)
 
-// MakeMapping は、マッピングを生成します
-func (m SampleMapping) MakeMapping() {
-	m["builtin_print"] = builtin_.PrintFunc
-	m["error_basic"] = error_.Basic
-	m["error_sentinel"] = error_.Sentinel
-	m["error_typeassertion"] = error_.TypeAssertion
-	m["error_wrap_unwrap"] = error_.WrapAndUnwrap
-	m["helloworld"] = helloworld.HelloWorld
-	m["printf01"] = stdout.Printf01
-	m["printf02"] = stdout.Printf02
-	m["printf03"] = stdout.Printf03
-	m["println01"] = stdout.Println01
-	m["scanner01"] = stdin.Scanner01
-	m["map_basic"] = map_.MapBasic
-	m["map_for"] = map_.MapFor
-	m["map_initialize"] = map_.MapInitialize
-	m["map_delete"] = map_.MapDelete
-	m["map_access"] = map_.MapAccess
-	m["scope01"] = scope.Scope01
-	m["async01"] = async.Async01
-	m["async_producer_consumer"] = async.ProducerConsumer
-	m["reflection01"] = reflection.Reflection01
-	m["import01"] = import_.Import01
-	m["iota01"] = iota_.Iota01
-	m["fileio01"] = io_.FileIo01
-	m["fileio02"] = io_.FileIo02
-	m["fileio03"] = io_.FileIo03
-	m["fileio04"] = io_.FileIo04
-	m["interface_basic"] = interface_.Basic
-	m["interface_composition"] = interface_.Composition
-	m["interface_ducktyping"] = interface_.DuckTyping
-	m["os01"] = os_.Os01
-	m["runtime01"] = runtime_.Runtime01
-	m["struct01"] = struct_.Struct01
-	m["struct02"] = struct_.Struct02
-	m["struct03"] = struct_.Struct03
-	m["struct04"] = struct_.Struct04
-	m["struct_anonymous_struct"] = struct_.StructAnonymousStruct
-	m["struct_empty_struct"] = struct_.EmptyStruct
-	m["array01"] = array_.Array01
-	m["slice01"] = slice_.Slice01
-	m["slice02"] = slice_.Slice02
-	m["slice03"] = slice_.Slice03
-	m["slice04"] = slice_.Slice04
-	m["slice05"] = slice_.Slice05
-	m["slice_reverse"] = slice_.SliceReverse
-	m["slice_append"] = slice_.SliceAppend
-	m["slice_pointer"] = slice_.SlicePointer
-	m["slice_copy"] = slice_.SliceCopy
-	m["slice_clear"] = slice_.SliceClear
-	m["comment01"] = comments.Comment01
-	m["closure01"] = closure.Closure01
-	m["string_rune_rawstring"] = string_.StringRuneRawString
-	m["string_to_runeslice"] = string_.StringToRuneSlice
-	m["string_rune_byte_convert"] = string_.StringRuneByteConvert
-	m["set01"] = sets.Set01
-	m["set02"] = sets.Set02
-	m["set03"] = sets.Set03
-	m["set04"] = sets.Set04
-	m["set05"] = sets.Set05
-	m["mapset01"] = sets.MapSet01
-	m["defer01"] = defer_.Defer01
-	m["var_statement_declare"] = variables.VarStatementDeclares
-	m["package_scope_variable"] = variables.PackageScopeVariable
-	m["short_assignment_statement"] = variables.ShortAssignmentStatement
-	m["const_statement_declare"] = constants.ConstStatementDeclares
-	m["function_one_return_value"] = functions.FunctionOneReturnValue
-	m["function_multi_return_value"] = functions.FunctionMultiReturnValue
-	m["function_named_return_value"] = functions.FunctionNamedReturnValue
-	m["type01"] = type_.Type01
-	m["minmax"] = math_.MinMax
-	m["binary_int_literals"] = literals.BinaryIntLiterals
-	m["octal_int_literals"] = literals.OctalIntLiterals
-	m["hex_int_literals"] = literals.HexIntLiterals
-	m["digit_separator"] = literals.DigitSeparators
-	m["time_since"] = time_.TimeSince
-	m["time_after"] = time_.TimeAfter
-	m["time_unix_to_time"] = time_.TimeUnixToTime
-	m["time_now"] = time_.TimeNow
-	m["time_parse"] = time_.TimeParse
-	m["hex_to_decimal_convert"] = strconv_.HexToDecimalConvert
-	m["unsafe_sizeof"] = unsafe_.Sizeof
-	m["log_flags"] = log_.Flags
-	m["log_prefix"] = log_.Prefix
-	m["log_sentry_basic"] = log_.SentryBasic
-	m["log_sentry_goroutine_bad"] = log_.SentryGoroutineBad
-	m["log_sentry_goroutine_good"] = log_.SentryGoroutineGood
-	m["log_output"] = log_.Output
-	m["log_new"] = log_.NewLogger
-	m["sort_interface"] = sort_.SortInterface
-	m["generate_generic_stack"] = generate.UseGenericStack
-	m["generate_generic_queue"] = generate.UseGenericQueue
-	m["xdg_base_directory"] = xdgspec.XdgBaseDirectory
-	m["xdg_user_directory"] = xdgspec.XdgUserDirectory
-	m["xdg_file_operation"] = xdgspec.XdgFileOperation
-	m["crypto_bcrypt_password_hash"] = crypto.BcryptPasswordHash
-
-	m["tutorial_gotour_helloworld"] = tutorial.HelloWorld
-	m["tutorial_gotour_import"] = tutorial.Import
-	m["tutorial_gotour_scope"] = tutorial.Scope
-	m["tutorial_gotour_functions"] = tutorial.Functions
-	m["tutorial_gotour_basictypes"] = tutorial.BasicTypes
-	m["tutorial_gotour_zerovalue"] = tutorial.ZeroValue
-	m["tutorial_gotour_typeconvert_basictypes"] = tutorial.TypeConvertBasicTypes
-	m["tutorial_gotour_const"] = tutorial.Constant
-	m["tutorial_gotour_forloop"] = tutorial.ForLoop
-	m["tutorial_gotour_if"] = tutorial.If
-	m["tutorial_gotour_switch"] = tutorial.Switch
-	m["tutorial_gotour_defer"] = tutorial.Defer
-	m["tutorial_gotour_pointer"] = tutorial.Pointer
-	m["tutorial_gotour_struct"] = tutorial.Struct
-	m["tutorial_gotour_array"] = tutorial.Array
-	m["tutorial_gotour_slice"] = tutorial.Slice
-	m["tutorial_gotour_map"] = tutorial.Map
-	m["tutorial_gotour_method"] = tutorial.Method
-	m["tutorial_gotour_interface"] = tutorial.Interface
-	m["tutorial_gotour_empty_interface"] = tutorial.EmptyInterface
-	m["tutorial_gotour_type_assertion"] = tutorial.TypeAssertion
-	m["tutorial_gotour_type_switch"] = tutorial.TypeSwitch
-	m["tutorial_gotour_stringer"] = tutorial.Stringer
-	m["tutorial_gotour_error"] = tutorial.Error
-	m["tutorial_gotour_reader"] = tutorial.Reader
-	m["tutorial_gotour_goroutine"] = tutorial.Goroutine
-	m["tutorial_gotour_channels"] = tutorial.Channels
-	m["tutorial_gotour_select"] = tutorial.Select
-	m["tutorial_gotour_mutex"] = tutorial.Mutex
-
-	m["effective_go_intro"] = effectivego.Introduction
-	m["effective_go_formatting"] = effectivego.Formatting
-	m["effective_go_comment"] = effectivego.Commentary
-	m["effective_go_names"] = effectivego.Names
-	m["effective_go_semicolon"] = effectivego.Semicolons
-	m["effective_go_control"] = effectivego.ControlStructure
-	m["effective_go_functions"] = effectivego.Functions
-	m["effective_go_defer"] = effectivego.Defer
-	m["effective_go_allocation_with_new"] = effectivego.AllocationWithNew
-	m["effective_go_constructors"] = effectivego.Constructors
-	m["effective_go_allocation_with_make"] = effectivego.AllocationWithMake
-	m["effective_go_arrays"] = effectivego.Arrays
-	m["effective_go_slices"] = effectivego.Slices
-	m["effective_go_two_dimentional_slices"] = effectivego.TwoDimentionalSlices
-	m["effective_go_maps"] = effectivego.Maps
-	m["effective_go_printing"] = effectivego.Printing
-	m["effective_go_append"] = effectivego.Append
-	m["effective_go_constants"] = effectivego.Constants
-	m["effective_go_methods"] = effectivego.Methods
+	return mapping
 }

--- a/tutorial/examples.go
+++ b/tutorial/examples.go
@@ -1,0 +1,47 @@
+package tutorial
+
+import (
+	"github.com/devlights/try-golang/interfaces"
+)
+
+type (
+	tutorialExampleRegister struct{}
+)
+
+// NewRegister は、tutorial パッケージ用の lib.Register を返します.
+func NewRegister() interfaces.Register {
+	r := new(tutorialExampleRegister)
+	return r
+}
+
+func (r *tutorialExampleRegister) Regist(m interfaces.SampleMapping) {
+	m["tutorial_gotour_helloworld"] = HelloWorld
+	m["tutorial_gotour_import"] = Import
+	m["tutorial_gotour_scope"] = Scope
+	m["tutorial_gotour_functions"] = Functions
+	m["tutorial_gotour_basictypes"] = BasicTypes
+	m["tutorial_gotour_zerovalue"] = ZeroValue
+	m["tutorial_gotour_typeconvert_basictypes"] = TypeConvertBasicTypes
+	m["tutorial_gotour_const"] = Constant
+	m["tutorial_gotour_forloop"] = ForLoop
+	m["tutorial_gotour_if"] = If
+	m["tutorial_gotour_switch"] = Switch
+	m["tutorial_gotour_defer"] = Defer
+	m["tutorial_gotour_pointer"] = Pointer
+	m["tutorial_gotour_struct"] = Struct
+	m["tutorial_gotour_array"] = Array
+	m["tutorial_gotour_slice"] = Slice
+	m["tutorial_gotour_map"] = Map
+	m["tutorial_gotour_method"] = Method
+	m["tutorial_gotour_interface"] = Interface
+	m["tutorial_gotour_empty_interface"] = EmptyInterface
+	m["tutorial_gotour_type_assertion"] = TypeAssertion
+	m["tutorial_gotour_type_switch"] = TypeSwitch
+	m["tutorial_gotour_stringer"] = Stringer
+	m["tutorial_gotour_error"] = Error
+	m["tutorial_gotour_reader"] = Reader
+	m["tutorial_gotour_goroutine"] = Goroutine
+	m["tutorial_gotour_channels"] = Channels
+	m["tutorial_gotour_select"] = Select
+	m["tutorial_gotour_mutex"] = Mutex
+}

--- a/tutorial/examples.go
+++ b/tutorial/examples.go
@@ -14,6 +14,7 @@ func NewRegister() interfaces.Register {
 	return r
 }
 
+// Regist は、tutorial パッケージ配下に存在するサンプルを登録します.
 func (r *tutorialExampleRegister) Regist(m interfaces.ExampleMapping) {
 	m["tutorial_gotour_helloworld"] = HelloWorld
 	m["tutorial_gotour_import"] = Import

--- a/tutorial/examples.go
+++ b/tutorial/examples.go
@@ -14,7 +14,7 @@ func NewRegister() interfaces.Register {
 	return r
 }
 
-func (r *tutorialExampleRegister) Regist(m interfaces.SampleMapping) {
+func (r *tutorialExampleRegister) Regist(m interfaces.ExampleMapping) {
 	m["tutorial_gotour_helloworld"] = HelloWorld
 	m["tutorial_gotour_import"] = Import
 	m["tutorial_gotour_scope"] = Scope


### PR DESCRIPTION
- インターフェースを挟んで分離させる
- MakeMapping() で全部一気に登録しているのを、各パッケージ側に処理委譲するようにする
- SampleXXとなっている部分をExampleXXという名前に変更